### PR TITLE
Fix coords

### DIFF
--- a/MOM_particles.F90
+++ b/MOM_particles.F90
@@ -74,15 +74,11 @@ subroutine particles_init(parts, Grid, Time, dt, u, v)
 
  integer :: io_layout(2)
  integer :: stdlogunit, stderrunit
- integer :: gni, gnj ! Global extent of ocean grid
 
  ! Get the stderr and stdlog unit numbers
  stderrunit=stderr()
  stdlogunit=stdlog()
  write(stdlogunit,*) "particles: "//trim(version)
-
- gni = Grid%ieg - Grid%isg + 1
- gnj = Grid%jeg - Grid%jsg + 1
 
  call particles_framework_init(parts, Grid, Time, dt)
  call mpp_clock_begin(parts%clock_ior)

--- a/MOM_particles_framework.F90
+++ b/MOM_particles_framework.F90
@@ -357,8 +357,8 @@ subroutine particles_framework_init(parts, Grid, Time, dt)
 
 
   is=grd%isc; ie=grd%iec; js=grd%jsc; je=grd%jec
-  grd%lon(is:ie,js:je)=Grid%geolonT(is:ie,js:je)
-  grd%lat(is:ie,js:je)=Grid%geolatT(is:ie,js:je)
+  grd%lon(is:ie,js:je)=Grid%geolonBu(is:ie,js:je)
+  grd%lat(is:ie,js:je)=Grid%geolatBu(is:ie,js:je)
   grd%area(is:ie,js:je)=Grid%areaT(is:ie,js:je) !sis2 has *(4.*pi*radius*radius)
   grd%ocean_depth(is:ie,js:je) = Grid%bathyT(is:ie,js:je)
   is=grd%isc; ie=grd%iec; js=grd%jsc; je=grd%jec


### PR DESCRIPTION
This fixes the obvious coordinate problem in the code.
- MOM6 cell-centers were being used as particle cell corners.
- The plot below is better than before.
- There are, however, some places where the trajectories appear to cross into land. I think they are not actually doing this in the code, so this might be a plotting artifact.

![image](https://user-images.githubusercontent.com/5859571/43217657-355e3976-9010-11e8-8d99-3a2d4c92d662.png)
